### PR TITLE
fix: use uuid as migration id when inserting new migration row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Deploy Player
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   build:

--- a/src/driver/spanner/SpannerDriver.ts
+++ b/src/driver/spanner/SpannerDriver.ts
@@ -139,7 +139,7 @@ export class SpannerDriver implements Driver {
         deleteDateNullable: true,
         version: "int64",
         treeLevel: "int64",
-        migrationId: "int64",
+        migrationId: "string",
         migrationName: "string",
         migrationTimestamp: "int64",
         cacheId: "string",


### PR DESCRIPTION
### Description of change

fix: use uuid as migration id when inserting new migration row

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
