### PR TITLE
feat: changed to use transaction instead of managing sessions manually. And only when a transaction is needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamyard/typeorm",
-  "version": "0.3.16-4",
+  "version": "0.3.16-5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@streamyard/typeorm",
   "private": true,
-  "version": "0.3.16-4",
+  "version": "0.3.16-5-beta",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB, Spanner databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -39,14 +39,9 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
     driver: SpannerDriver
 
     /**
-     * Real database connection from a connection pool used to perform queries.
+     * Transaction currently executed.
      */
-    protected session?: any
-
-    /**
-     * Transaction currently executed by this session.
-     */
-    protected sessionTransaction?: any
+    protected currentTransaction?: any
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -69,14 +64,14 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Returns obtained database connection.
      */
     async connect(): Promise<any> {
-        if (this.session) {
-            return Promise.resolve(this.session)
-        }
+        return Promise.resolve(this.driver.instanceDatabase)
+    }
 
-        const [session] = await this.driver.instanceDatabase.createSession({})
-        this.session = session
-        this.sessionTransaction = await session.transaction()
-        return this.session
+    protected async initTransaction() {
+        const [transaction] =
+            await this.driver.instanceDatabase.getTransaction()
+        this.currentTransaction = transaction
+        return this.currentTransaction
     }
 
     /**
@@ -85,10 +80,10 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     async release(): Promise<void> {
         this.isReleased = true
-        if (this.session) {
-            await this.session.delete()
+        if (this.currentTransaction) {
+            await this.currentTransaction.end()
         }
-        this.session = undefined
+        this.currentTransaction = undefined
         return Promise.resolve()
     }
 
@@ -104,8 +99,8 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             throw err
         }
 
-        await this.connect()
-        await this.sessionTransaction.begin()
+        await this.initTransaction()
+        await this.currentTransaction.begin()
         this.connection.logger.logQuery("START TRANSACTION")
 
         await this.broadcaster.broadcast("AfterTransactionStart")
@@ -116,12 +111,12 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Error will be thrown if transaction was not started.
      */
     async commitTransaction(): Promise<void> {
-        if (!this.isTransactionActive || !this.sessionTransaction)
+        if (!this.isTransactionActive || !this.currentTransaction)
             throw new TransactionNotStartedError()
 
         await this.broadcaster.broadcast("BeforeTransactionCommit")
 
-        await this.sessionTransaction.commit()
+        await this.currentTransaction.commit()
         this.connection.logger.logQuery("COMMIT")
         this.isTransactionActive = false
 
@@ -133,12 +128,12 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Error will be thrown if transaction was not started.
      */
     async rollbackTransaction(): Promise<void> {
-        if (!this.isTransactionActive || !this.sessionTransaction)
+        if (!this.isTransactionActive || !this.currentTransaction)
             throw new TransactionNotStartedError()
 
         await this.broadcaster.broadcast("BeforeTransactionRollback")
 
-        await this.sessionTransaction.rollback()
+        await this.currentTransaction.rollback()
         this.connection.logger.logQuery("ROLLBACK")
         this.isTransactionActive = false
 
@@ -157,7 +152,6 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         try {
             const queryStartTime = +new Date()
-            await this.connect()
             let rawResult:
                 | [
                       any[],
@@ -171,13 +165,17 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                   ]
                 | undefined = undefined
             const isSelect = query.startsWith("SELECT")
+            if (!isSelect && !this.isTransactionActive) {
+                await this.initTransaction()
+            }
+
             const executor =
                 isSelect && !this.isTransactionActive
                     ? this.driver.instanceDatabase
-                    : this.sessionTransaction
+                    : this.currentTransaction
 
             if (!this.isTransactionActive && !isSelect) {
-                await this.sessionTransaction.begin()
+                await this.currentTransaction.begin()
             }
 
             try {
@@ -193,13 +191,13 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                     json: true,
                 })
                 if (!this.isTransactionActive && !isSelect) {
-                    await this.sessionTransaction.commit()
+                    await this.currentTransaction.commit()
                 }
             } catch (error) {
                 try {
                     // we throw original error even if rollback thrown an error
                     if (!this.isTransactionActive && !isSelect)
-                        await this.sessionTransaction.rollback()
+                        await this.currentTransaction.rollback()
                 } catch (rollbackError) {}
                 throw error
             }

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -167,18 +167,15 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                   ]
                 | undefined = undefined
             const isSelect = query.startsWith("SELECT")
-            if (!isSelect && !this.isTransactionActive) {
+            if (!this.isTransactionActive && !isSelect) {
                 await this.initTransaction()
+                await this.currentTransaction.begin()
             }
 
             const executor =
                 isSelect && !this.isTransactionActive
                     ? this.driver.instanceDatabase
                     : this.currentTransaction
-
-            if (!this.isTransactionActive && !isSelect) {
-                await this.currentTransaction.begin()
-            }
 
             try {
                 this.driver.connection.logger.logQuery(query, parameters, this)

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -68,6 +68,8 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
     }
 
     protected async initTransaction() {
+        if (this.currentTransaction) return this.currentTransaction
+
         const [transaction] =
             await this.driver.instanceDatabase.getTransaction()
         this.currentTransaction = transaction


### PR DESCRIPTION
### Description of change

Stop opening sessions manually. Based on the spanner code, this should not be done. 
https://github.com/googleapis/nodejs-spanner/blob/65f6a838be9f526cb2c1497c66345ef2949e35d4/src/session.ts#L77

Use `database.getTransaction` instead and only when a transaction is needed. 

We want to do this as we have realised that we are constantly creating and deleting sessions in spanner

<img width="1544" alt="image" src="https://github.com/streamyard/typeorm/assets/123395506/b3e7180a-c041-42cd-b4c8-42e80faf0529">

<img width="1564" alt="image" src="https://github.com/streamyard/typeorm/assets/123395506/802d3989-d122-4b20-b04f-c6ebe5f30768">


We hope that this will improve the performance. 
